### PR TITLE
Fix bug when validate envs with joi

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/orochi-network/framework#readme",
   "dependencies": {
-    "chalk": "^5.3.0",
+    "chalk": "4.1.2",
     "dotenv": "^16.3.1",
     "joi": "^17.9.2",
     "js-sha3": "^0.8.0",

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -1,7 +1,7 @@
-import fs from "fs";
-import Joi from "joi";
-import { parse } from "dotenv";
-import { Obj } from "./utilities";
+import fs from 'fs';
+import Joi from 'joi';
+import { parse } from 'dotenv';
+import { Obj } from './utilities';
 
 export class ConfigLoader {
   private envs: any;
@@ -14,8 +14,7 @@ export class ConfigLoader {
       // Otherwise load from process.env
       this.envs = Obj.objToCamelCase(process.env);
     }
-    if (typeof validators !== "undefined") {
-      this.envs = validators.validate(this.envs);
+    if (typeof validators !== 'undefined') {
       const result = validators.validate(this.envs);
       if (result.error) {
         throw new Error(result.error.message);

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,18 +462,13 @@ callsites@^3.0.0:
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-chalk@^4.0.0:
+chalk@4.1.2, chalk@^4.0.0:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
-
-chalk@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
-  integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
 
 color-convert@^1.9.3:
   version "1.9.3"
@@ -1279,7 +1274,7 @@ isexe@^2.0.0:
 
 joi@^17.9.2:
   version "17.9.2"
-  resolved "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.9.2.tgz#8b2e4724188369f55451aebd1d0b1d9482470690"
   integrity sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==
   dependencies:
     "@hapi/hoek" "^9.0.0"


### PR DESCRIPTION
Changes note:
- Fix bug when validate envs with joi
- Change `chalk` version to 4.1.2 due to conflict esm and cjs module with `knexjs`